### PR TITLE
Add support for specifying -currentHost or -host <hostname>

### DIFF
--- a/manifests/osx_defaults.pp
+++ b/manifests/osx_defaults.pp
@@ -4,8 +4,17 @@ define osx_defaults(
   $key    = undef,
   $value  = undef,
   $user   = undef,
+  $host   = undef,
 ) {
   $defaults_cmd = "/usr/bin/defaults"
+
+  if $host != undef {
+    if $host == 'currentHost' {
+      $defaults_cmd = "${defaults_cmd} -currentHost"
+    } else {
+      $defaults_cmd = "${defaults_cmd} -host ${host}"
+    }
+  }
 
   if $ensure == 'present' {
     if ($domain != undef) and ($key != undef) and ($value != undef) {


### PR DESCRIPTION
I have absolutely no idea if this is a good idea or not (or if this
change even works), but I was trying to add some osx_default rules
that needed defined with the -currentHost param as well as without.

An example of a rules would be L#99 here:
https://github.com/mathiasbynens/dotfiles/blob/master/.osx#L99-L100
