### PR TITLE
Added type & host parameters to osx_defaults type

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 This is a simple puppet module for managing the defaults system in OS X.
 
 It currently has support for defaults domain keys whose values are
-boolean, integer, or string types.
+string, data, int, float, bool, date, array, array-add, dict and dict-add. The
+default key type is string.
+
+Refer to the [defaults(1)](https://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man1/defaults.1.html) manpage for further information on how to set key
+values.
 
 ## Requirements
 
@@ -19,7 +23,8 @@ osx_defaults { "require pass at screensaver":
   domain => 'com.apple.screensaver',
   key    => 'askForPassword',
   value  => 1,
-  user   => 'dummy'
+  user   => 'dummy',
+  type   => 'int'
 }
 ```
 

--- a/manifests/osx_defaults.pp
+++ b/manifests/osx_defaults.pp
@@ -3,20 +3,35 @@ define osx_defaults(
   $domain = undef,
   $key    = undef,
   $value  = undef,
-  $user   = undef,
+  $host   = undef,
+  $user   = 'root',
+  $type   = 'string',
 ) {
-  $defaults_cmd = "/usr/bin/defaults"
+  $defaults_cmd = '/usr/bin/defaults'
+
+  if $host == undef {
+    $host_arg = '-currentHost'
+  } else {
+    $host_arg = "-host ${host}"
+  }
 
   if $ensure == 'present' {
-    if ($domain != undef) and ($key != undef) and ($value != undef) {
+    if $type =~ /string|data|int|float|bool|date|array|array-add|dict|dict-add/ {
+      $type_arg = "-${type}"
+    } else {
+      warn('Invalid type declared')
+    }
+
+    if $domain or $key or $value != undef {
       exec { "osx_defaults write ${domain}:${key}=>${value}":
-        command => "${defaults_cmd} write ${domain} ${key} ${value}",
+        command => "${defaults_cmd} ${host_arg} write ${domain} ${type_arg} ${key} ${value}",
         unless  => "${defaults_cmd} read ${domain} ${key}|egrep '^${value}$'",
         user    => $user
       }
     } else {
-      warn("Cannot ensure present without domain, key, and value attributes")
+      warn('Cannot ensure present without domain, key, and value attributes')
     }
+
   } else {
     exec { "osx_defaults delete ${domain}:${key}":
       command => "${defaults_cmd} delete ${domain} ${key}",

--- a/manifests/osx_defaults.pp
+++ b/manifests/osx_defaults.pp
@@ -1,10 +1,31 @@
+# Defined type: osx_defaults
+#
+# Manages the defaults system in Mac OS X.
+#
+# It currently has support for defaults domain keys whose values are
+# string, data, int, float, bool, date, array, array-add, dict and dict-add. The
+# default key type is string.
+#
+# Refer to the defaults(1) manpage for further information on how to set key 
+# values.
+#
+# Usage:
+# osx_defaults {' require pass at screensaver':
+#   ensure => present,
+#   domain => 'com.apple.screensaver',
+#   key    => 'askForPassword',
+#   value  => 1,
+#   user   => 'dummy',
+#   type   => 'int'
+# }
+#
 define osx_defaults(
   $ensure = 'present',
   $domain = undef,
   $key    = undef,
   $value  = undef,
   $host   = undef,
-  $user   = 'root',
+  $user   = undef,
   $type   = 'string',
 ) {
   $defaults_cmd = '/usr/bin/defaults'


### PR DESCRIPTION
- added type parameter for setting types to keys eg: string, bool, int,array, etc
- added option for defaults host option
