### PR TITLE
added host parameter

### DIFF
--- a/KNOWN_KEYS.md
+++ b/KNOWN_KEYS.md
@@ -1,0 +1,28 @@
+List of often used keys
+-----------------------
+
+Finder
+------
+
+Domain: com.apple.finder
+
+WARNING: You need to kill Finder to activate this settings
+
+Key											Values		Description
+
+ShowHardDrivesOnDesktop					0/1
+ShowExternalHardDrivesOnDesktop		0/1
+ShowMountedServersOnDesktop			0/1
+ShowRemovableMediaOnDesktop			0/1
+
+Screensaver:
+------------
+
+WARNING: Settings are changed but will not be activated by the screensaver!!!!
+
+Domain: com.apple.screensaver
+
+Key					Values		Description
+
+idleTime				Int			Time until screensaver is started
+askForPassword		0/1			Ask for Password

--- a/manifests/osx_defaults.pp
+++ b/manifests/osx_defaults.pp
@@ -18,8 +18,8 @@ define osx_defaults(
   if $ensure == 'present' {
     if ($domain != undef) and ($key != undef) and ($value != undef) {
       exec { "osx_defaults write ${domain}:${key}=>${value}":
-        command => "${defaults_cmd} $hostarg write ${domain} ${key} ${value}",
-        unless  => "${defaults_cmd} $hostarg read ${domain} ${key}|egrep '^${value}$'",
+        command => "${defaults_cmd} $hostarg write ${domain} '${key}' ${value}",
+        unless  => "${defaults_cmd} $hostarg read ${domain} '${key}'|egrep '^${value}$'",
         user    => $user
       }
     } else {
@@ -30,7 +30,7 @@ define osx_defaults(
     }
   } else {
     exec { "osx_defaults delete ${domain}:${key}":
-      command => "${defaults_cmd} $hostarg delete ${domain} ${key}",
+      command => "${defaults_cmd} $hostarg delete ${domain} '${key}'",
       onlyif  => "${defaults_cmd} $hostarg read ${domain} | grep ${key}",
       user    => $user
     }

--- a/manifests/osx_defaults.pp
+++ b/manifests/osx_defaults.pp
@@ -4,24 +4,36 @@ define osx_defaults(
   $key    = undef,
   $value  = undef,
   $user   = undef,
+  $host   = "",
 ) {
   $defaults_cmd = "/usr/bin/defaults"
-
+  if $host == "local" {
+    $hostarg="-currentHost"
+  }elsif $host != ""{
+    $hostarg="-host $host"
+  }else{
+    $hostarg=""
+  }
+  
   if $ensure == 'present' {
     if ($domain != undef) and ($key != undef) and ($value != undef) {
       exec { "osx_defaults write ${domain}:${key}=>${value}":
-        command => "${defaults_cmd} write ${domain} ${key} ${value}",
-        unless  => "${defaults_cmd} read ${domain} ${key}|egrep '^${value}$'",
+        command => "${defaults_cmd} $hostarg write ${domain} ${key} ${value}",
+        unless  => "${defaults_cmd} $hostarg read ${domain} ${key}|egrep '^${value}$'",
         user    => $user
       }
     } else {
-      warn("Cannot ensure present without domain, key, and value attributes")
+      notify { "osx_defaults_warn":
+        message => "Cannot ensure present without domain, key, and value attributes",
+      }
+
     }
   } else {
     exec { "osx_defaults delete ${domain}:${key}":
-      command => "${defaults_cmd} delete ${domain} ${key}",
-      onlyif  => "${defaults_cmd} read ${domain} | grep ${key}",
+      command => "${defaults_cmd} $hostarg delete ${domain} ${key}",
+      onlyif  => "${defaults_cmd} $hostarg read ${domain} | grep ${key}",
       user    => $user
     }
   }
 }
+


### PR DESCRIPTION
Hi 

I added the host parameter for the defaults command. This is needed to access settings like screensaver timeouts.

Example:

osx_defaults{ "screensaver_timeout":
  domain => "com.apple.screensaver",
  key => "idleTime",
  value  => screensaver_timeout,
  user   => $user,
  host   => "local",
}
